### PR TITLE
Account info

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -3,6 +3,7 @@ class AccountsController < ApplicationController
 
   def create
     current_user.accounts.find_or_create_from_omniauth(env['omniauth.auth'])
+    current_user.update_attributes!(image: env['omniauth.auth']['extra']['raw_info']['profile_picture_url'])
     redirect_to society_user_path(current_society)
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,6 +7,7 @@ class Account < ActiveRecord::Base
       account.provider = omniauth_hash[:provider]
       account.uid = omniauth_hash[:uid]
       account.token = omniauth_hash[:credentials][:token]
+      account.identifier = omniauth_hash[:info][:username]
       account.save
     end
   end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,6 +4,11 @@
   <%= devise_error_messages! %>
 
   <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true %>
   </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,8 +1,7 @@
   <div class="sidebar">
     <h1 class="society-header"><%= current_user.society.name %></h1>
-    <img class="account-photo" src="http://www.genengnews.com/app_themes/genconnect/images/default_profile.jpg" alt="profile_picture">
+    <img class="account-photo" src=<%= current_user.image %> alt="profile_picture">
     <p><%= current_user.name %></p>
-    <p><%= current_user.email %></p>
     <div class="balance">
       <div class="balance-header">total owed</div>
       <h2 class="balance-amt"><%= current_user.total_owed %></h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,15 +3,19 @@
   <div class="main-content">
     <%= render "/shared/user_nav" %>
     <div class="content">
-      <a href="/auth/venmo" class="btn add-account-btn">Link Venmo Account</a>
+      <% if current_user.accounts.empty? %><a href="/auth/venmo" class="btn add-account-btn">Link Venmo Account</a><% end %>
       <div class="payment-accounts">
         <% current_user.accounts.each do |account| %>
           <div class="payment-account">
-            <h3 class="account-name"><%= account.provider %></h3>
             <table class="payment-account-table">
               <tr>
-                <td>Name</td>
-                <td>XXXX</td>
+                <th>Provider</th>
+                <th>Username</th>
+                <th></th>
+              </tr>
+              <tr>
+                <td><h3 class="account-name"><%= account.provider %></td>
+                <td><%= account.identifier %></td>
                 <td><%= link_to "Unlink", society_user_account_path(current_user, account), method: "DELETE", class:"btn" %></td>
               </tr>
             </table>

--- a/db/migrate/20151108221513_add_identifier_to_account.rb
+++ b/db/migrate/20151108221513_add_identifier_to_account.rb
@@ -1,0 +1,5 @@
+class AddIdentifierToAccount < ActiveRecord::Migration
+  def change
+    add_column :accounts, :identifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151107212817) do
+ActiveRecord::Schema.define(version: 20151108221513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20151107212817) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "identifier"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/integration/account_auth_spec.rb
+++ b/spec/integration/account_auth_spec.rb
@@ -12,11 +12,17 @@ RSpec.describe "User can authorize account", type: :feature do
   end
 
   it "creates an account" do
-    expect(page).to have_content("Name")
+    within('.payment-account-table') do
+      expect(page).to have_content("venmo")
+      expect(page).to have_content("test-user")
+    end
+    expect(page).to_not have_content('Link Venmo Account')
   end
 
   it "deletes an account" do
     click_on "Unlink"
-    expect(page).to_not have_content("Name")
+    expect(page).to_not have_content("venmo")
+    expect(page).to_not have_content("test-user")
+    expect(page).to have_content('Link Venmo Account')
   end
 end

--- a/spec/integration/expense_spec.rb
+++ b/spec/integration/expense_spec.rb
@@ -1,14 +1,13 @@
 require 'rails_helper'
 RSpec.describe "Expenses", type: :feature do
-  before do
-    @society = Society.create!(name: "Test")
-    @user = User.create!(name: "Test User", email: "test@test.com", password: "password", password_confirmation: "password", society: @society)
-    @user2 = User.create!(name: "Other User", email: "other@test.com", password: "password", password_confirmation: "password", society: @society)
-  end
+  let(:society) { Society.create!(name: "Test") }
+  let!(:user) { User.create!(name: "Test User", email: "test@test.com", password: "password", password_confirmation: "password", society: society) }
+  let!(:user2) { User.create!(name: "Other User", email: "other@test.com", password: "password", password_confirmation: "password", society: society) }
+  let(:expense) { Expense.create!(name: "Electricity", description: "All That Power", amount: 100, society: society, user: user) }
 
   context "existing expenses" do
     before do
-      Expense.create(name: "Electricity", description: "All That Power", amount: 100, society: @society, user: @user)
+      expense.build_payments && expense.save!
       visit '/'
       login
       click_on "Expenses"

--- a/spec/integration/sign_up_spec.rb
+++ b/spec/integration/sign_up_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "User can sign-up", type: :feature do
       fill_in 'society[name]', with: 'test'
       click_on "Create Society"
 
-      expect(page).to have_content 'test@test.com'
+      within('.sidebar') do
+        expect(page).to have_content 'Test User'
+      end
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Account do
     let(:omniauth_hash) { {
       provider: 'venmo',
       uid: '123545',
+      info: {
+        username: 'test-user',
+      },
       credentials: {
         token: 'token'
       },

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Account do
       credentials: {
         token: 'token'
       },
+      extra: {
+        raw_info: {
+          profile_picture_url: 'img.img'
+        }
+      }
     }}
 
     context "a new user" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,14 +21,13 @@ OmniAuth.config.mock_auth[:venmo] = OmniAuth::AuthHash.new({
   provider: 'venmo',
   uid: '123545',
   info: {
-    balance: '0.0'
+    username: 'test-user',
   },
   credentials: {
     token: 'token'
   },
   extra: {
     raw_info: {
-      display_name: 'Test User',
       profile_picture_url: 'img.img'
     }
   }


### PR DESCRIPTION
- Adds ability to update user's name
- Uses image in omniauth hash as user's image
- Add an identifier to account
- Show provider/identifier on account page
- Specs

Closes #4 
