### PR TITLE
Notify users when payment is requested

### DIFF
--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -1,0 +1,9 @@
+class PaymentMailer < ActionMailer::Base
+  default from: 'notifications@rmmts.com'
+
+  def payment_notification_email(payment)
+    @user = payment.payer
+    @payee = payment.payee
+    mail(to: @user.email, subject: "#{@payee.name || @payee.email} has requested a payment")
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -5,6 +5,7 @@ class Payment < ActiveRecord::Base
   belongs_to :expense
 
   after_create :use_credit
+  after_create :notify_user
 
   scope :paid, -> { where.not(paid_at: nil) }
   scope :unpaid, -> { where(paid_at: nil) }
@@ -19,6 +20,10 @@ class Payment < ActiveRecord::Base
       update_attributes!(amount: amount - payer.credit)
       payer.update_attributes!(credit: 0)
     end
+  end
+
+  def notify_user
+    PaymentMailer.delay.payment_notification_email(self)
   end
 
   def pay

--- a/app/views/payment_mailer/payment_notification_email.html.erb
+++ b/app/views/payment_mailer/payment_notification_email.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1><%= @user.name || @user.email %>,</h1>
+    <p><%= @payee.name || @payee.email %> has requested a payment on RMMTS.</p>
+    <p>If you think this is in error, talk to them about it.</p>
+  </body>
+</html>

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe PaymentMailer do
+  describe "#payment_notification_email" do
+    let(:payee) { User.create!(email: "test@example.com", password: "password", name: "Test")}
+    let(:payer) { User.create!(email: "test2@example.com", password: "password", name: "Other", credit_cents: 500)}
+    let(:payment) { Payment.create!(payer: payer, payee: payee, amount_cents: 100) }
+    let(:mail) { PaymentMailer.payment_notification_email(payment) }
+
+    it "renders the subject" do
+      expect(mail.subject).to eq("#{payee.name} has requested a payment")
+    end
+
+    it "renders the receiver email" do
+      expect(mail.to).to eq([payer.email])
+    end
+
+    it "renders the sender email" do
+      expect(mail.from).to eq(['notifications@rmmts.com'])
+    end
+  end
+end


### PR DESCRIPTION
When a payment is created, send an email notifying the user that a payment has been requested of them.
- Add PaymentMailer class
- Add after_create hook on Payment to send emails
- Add PaymentNotificationEmail template
- Specs
